### PR TITLE
Don't die when asked for a nonexisting package

### DIFF
--- a/lib/Parse/CPAN/Packages/Fast.pm
+++ b/lib/Parse/CPAN/Packages/Fast.pm
@@ -73,7 +73,7 @@ use CPAN::DistnameInfo ();
 
     sub package {
 	my($self, $package_name) = @_;
-	die "Package $package_name does not exist" if !exists $self->{pkg_ver}{$package_name}; # XXX die or not?
+	return undef if !exists $self->{pkg_ver}{$package_name};
 	Parse::CPAN::Packages::Fast::Package->new($package_name, $self);
     }
 


### PR DESCRIPTION
Hi Slaven,

I recently switch from using Parse::CPAN::Packages to Parse::CPAN::Packages::Fast for my turn-cpan-into-an-rpm-repository toolkit due to the dramatic speedups, thanks very much for that! 

There is however one issue, Parse::CPAN::Packages::Fast dies when asked about nonexisting packages, while Parse::CPAN::Packages returns undef.

Returning undef makes more sense to me, so I patched Parse::CPAN::Packages::Fast locally to do the same. Given that there was a comment '# XXX die or not?' in the relevant line, I hope you agree and merge this pull request :)
- 
  Dennis Kaarsemaker
