### PR TITLE
Use the packages file located for tests instead of defaulting interactive

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -20,7 +20,7 @@ SKIP: {
 	skip "Cannot get default CPAN packages index file", $real_tests;
     }	
 
-    my $pcp = Parse::CPAN::Packages::Fast->new;
+    my $pcp = Parse::CPAN::Packages::Fast->new($packages_file);
     isa_ok($pcp, 'Parse::CPAN::Packages::Fast');
 
     cmp_ok($pcp->package_count, ">", 10000);

--- a/t/module_lookup.t
+++ b/t/module_lookup.t
@@ -24,7 +24,7 @@ SKIP: {
     skip "Cannot get default CPAN packages index file", 1
 	if !$orig_packages_file;
 
-    my $pcpf = Parse::CPAN::Packages::Fast->new;
+    my $pcpf = Parse::CPAN::Packages::Fast->new($orig_packages_file);
     my $i = 0;
     for my $package ($pcpf->packages) {
 	my $ret = Parse::CPAN::Packages::Fast->_module_lookup($package, $orig_packages_file, $cache_file);


### PR DESCRIPTION
Tests once again work if you haven't configured CPAN.pm.  Previous
behaviour was to hang while CPAN.pm silently (!) prompted for
configuration.  Various commits since 0.05 attempting to fix the issue
forgot to pass the package file to the module's ->new invocation, which
let it fallback to interactive behaviour.

Resolves [rt.cpan.org #66555].
